### PR TITLE
Add Dynamic Crouch Height cvar, Server cvars to Q menu

### DIFF
--- a/lua/enhanced_camera_2/client.lua
+++ b/lua/enhanced_camera_2/client.lua
@@ -562,9 +562,29 @@ hook.Add("PopulateToolMenu", "EnhancedCameraTwo:PopulateToolMenu", function()
 
 		panel:CheckBox("Dynamic view height", "cl_ec2_dynamicheight")
 		panel:ControlHelp("Dynamically adjust your view height to match your model.")
-
+		
 		panel:Button("Reload model", "cl_ec2_refresh")
 		panel:ControlHelp("Forces a model reload. May be useful if the first-person model doesn't update after changing your playermodel for some reason.")
+
+	end)
+	
+	spawnmenu.AddToolMenuOption("Options", "Player", "EnhancedCamera2Server", "Enhanced Camera 2 Server", "", "", function(panel)
+
+		panel:ClearControls()
+
+		panel:Help("Welcome to the Enhanced Camera 2 server settings.")
+
+		panel:CheckBox("Dynamic Height", "sv_ec2_dynamicheight")
+		panel:ControlHelp("Dynamically adjust players' view heights to match their models")
+
+		panel:CheckBox("Dynamic Height while Crouched", "sv_ec2_dynamicheight_crouch")
+		panel:ControlHelp("Dynamically adjust players' view heights to match their models while holding Crouch bind. If disabled, crouch height will not be dynamic.")
+
+		panel:NumSlider("Maximum View Height", "sv_ec2_dynamicheight_max", 0, 100)
+		panel:ControlHelp("Maximum View Height")
+
+		panel:NumSlider("Minimum view height", "sv_ec2_dynamicheight_min", 0, 100)
+		panel:ControlHelp("Minimum view height")
 
 	end)
 end)

--- a/lua/enhanced_camera_2/server.lua
+++ b/lua/enhanced_camera_2/server.lua
@@ -38,7 +38,7 @@ local function UpdateView(ply)
 
 		-- Find the height by spawning a dummy entity
 		local height = GetViewOffsetValue(ply, "idle_all_01")
-		local crouch = GetViewOffsetValue(ply, "cwalk_all")
+		local crouch = GetViewOffsetValue(ply, "cidle_all")
 
 		-- Update player height
 		local min = cvarHeightMin:GetInt()


### PR DESCRIPTION
Created the option to enable/disable dynamic height adjustment while Crouch Bind is held. When enabled, crouching while moving can cause camera to clip through surfaces above model, in addition to the somewhat laggyness of having to dynamically set view height while crouch walking. When disabled, crouch height is set by dynamic height min value. Side effect of disabling this is model will clip through ground slightly.

![image](https://user-images.githubusercontent.com/34873184/104403768-18dd6e00-550e-11eb-9d4d-869d888b04ca.png)

Also added server cvars to Q menu.

![image](https://user-images.githubusercontent.com/34873184/104403476-71603b80-550d-11eb-84a0-39a191f57fa5.png)
